### PR TITLE
Fix IME input issues by implementing Ctrl/Cmd+Enter submission

### DIFF
--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -35,10 +35,9 @@ export const InputForm: React.FC<InputFormProps> = ({
     setInternalInputValue("");
   };
 
-  const handleInternalKeyDown = (
-    e: React.KeyboardEvent<HTMLTextAreaElement>
-  ) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Submit with Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac)
+    if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       handleInternalSubmit();
     }
@@ -59,9 +58,9 @@ export const InputForm: React.FC<InputFormProps> = ({
         <Textarea
           value={internalInputValue}
           onChange={(e) => setInternalInputValue(e.target.value)}
-          onKeyDown={handleInternalKeyDown}
+          onKeyDown={handleKeyDown}
           placeholder="Who won the Euro 2024 and scored the most goals?"
-          className={`w-full text-neutral-100 placeholder-neutral-500 resize-none border-0 focus:outline-none focus:ring-0 outline-none focus-visible:ring-0 shadow-none 
+          className={`w-full text-neutral-100 placeholder-neutral-500 resize-none border-0 focus:outline-none focus:ring-0 outline-none focus-visible:ring-0 shadow-none
                         md:text-base  min-h-[56px] max-h-[200px]`}
           rows={1}
         />


### PR DESCRIPTION
## Description

This PR fixes the issue where pressing Enter to confirm IME (Input Method Editor) input would inadvertently submit the form. This was particularly problematic for users typing in Japanese, Chinese, Korean, and other languages that use IME.

## Changes

- **Removed automatic form submission on Enter key**: The form no longer submits when pressing Enter alone, allowing IME users to confirm their input without triggering submission
- **Added keyboard shortcuts for submission**: 
  - `Ctrl+Enter` on Windows/Linux
  - `Cmd+Enter` on macOS
- **Preserved standard textarea behavior**: Users can still insert line breaks using `Shift+Enter`

## Problem it solves

Previously, when typing in languages that require IME (e.g., Japanese), pressing Enter to confirm character conversion would submit the form prematurely. This made it impossible to type multi-character words properly.

### Before
- Enter → Submits form (even during IME conversion)
- No way to properly input IME-based languages

### After
- Enter → Confirms IME input / inserts line break
- Ctrl/Cmd+Enter → Submits form
- Shift+Enter → Inserts line break (unchanged)

## Testing

1. Test with IME-based input (Japanese, Chinese, Korean)
   - Type characters requiring conversion
   - Press Enter to confirm conversion
   - Verify form is NOT submitted
   
2. Test form submission
   - Type any text
   - Press Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac)
   - Verify form IS submitted

3. Test line breaks
   - Type text and press Shift+Enter
   - Verify new line is created
