### PR TITLE
Fix: TypeError: Cannot read properties of undefined (reading 'join')

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,9 +54,11 @@ export default function App() {
           title: "Reflection",
           data: event.reflection.is_sufficient
             ? "Search successful, generating final answer."
-            : `Need more information, searching for ${event.reflection.follow_up_queries.join(
-                ", "
-              )}`,
+            : `Need more information, searching for ${
+                Array.isArray(event.reflection.follow_up_queries)
+                  ? event.reflection.follow_up_queries.join(", ")
+                  : "additional information"
+              }`,
         };
       } else if (event.finalize_answer) {
         processedEvent = {


### PR DESCRIPTION
Fix: TypeError: Cannot read properties of undefined (reading 'join') for the frontend to work correctly

ERROR

![The TypeError](https://ik.imagekit.io/fredsrocha/github/pr/google-gemini/gemini-fullstack-langgraph-quickstart/error-cannot-read-properties-of-undefined-reading-join.png?updatedAt=1749067309159)

FIX (now)

![The TypeError](https://ik.imagekit.io/fredsrocha/github/pr/google-gemini/gemini-fullstack-langgraph-quickstart/fix-cannot-read-properties-of-undefined-reading-join(1).png?updatedAt=1749067309745)
