### PR TITLE
fix: resolve chat UI scrolling issues with flexbox layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,13 +75,9 @@ export default function App() {
   });
 
   useEffect(() => {
+    // チャットエリア内で最下部にスクロール
     if (scrollAreaRef.current) {
-      const scrollViewport = scrollAreaRef.current.querySelector(
-        "[data-radix-scroll-area-viewport]"
-      );
-      if (scrollViewport) {
-        scrollViewport.scrollTop = scrollViewport.scrollHeight;
-      }
+      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
     }
   }, [thread.messages]);
 
@@ -154,30 +150,24 @@ export default function App() {
 
   return (
     <div className="flex h-screen bg-neutral-800 text-neutral-100 font-sans antialiased">
-      <main className="flex-1 flex flex-col overflow-hidden max-w-4xl mx-auto w-full">
-        <div
-          className={`flex-1 overflow-y-auto ${
-            thread.messages.length === 0 ? "flex" : ""
-          }`}
-        >
-          {thread.messages.length === 0 ? (
-            <WelcomeScreen
-              handleSubmit={handleSubmit}
-              isLoading={thread.isLoading}
-              onCancel={handleCancel}
-            />
-          ) : (
-            <ChatMessagesView
-              messages={thread.messages}
-              isLoading={thread.isLoading}
-              scrollAreaRef={scrollAreaRef}
-              onSubmit={handleSubmit}
-              onCancel={handleCancel}
-              liveActivityEvents={processedEventsTimeline}
-              historicalActivities={historicalActivities}
-            />
-          )}
-        </div>
+      <main className="flex-1 flex flex-col max-w-4xl mx-auto w-full">
+        {thread.messages.length === 0 ? (
+          <WelcomeScreen
+            handleSubmit={handleSubmit}
+            isLoading={thread.isLoading}
+            onCancel={handleCancel}
+          />
+        ) : (
+          <ChatMessagesView
+            messages={thread.messages}
+            isLoading={thread.isLoading}
+            scrollAreaRef={scrollAreaRef}
+            onSubmit={handleSubmit}
+            onCancel={handleCancel}
+            liveActivityEvents={processedEventsTimeline}
+            historicalActivities={historicalActivities}
+          />
+        )}
       </main>
     </div>
   );

--- a/frontend/src/components/ChatMessagesView.tsx
+++ b/frontend/src/components/ChatMessagesView.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import type { Message } from "@langchain/langgraph-sdk";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Loader2, Copy, CopyCheck } from "lucide-react";
 import { InputForm } from "@/components/InputForm";
 import { Button } from "@/components/ui/button";
@@ -253,7 +252,7 @@ export function ChatMessagesView({
 
   return (
     <div className="flex flex-col h-full">
-      <ScrollArea className="flex-grow" ref={scrollAreaRef}>
+      <div className="flex-1 overflow-y-auto" ref={scrollAreaRef}>
         <div className="p-4 md:p-6 space-y-2 max-w-4xl mx-auto pt-16">
           {messages.map((message, index) => {
             const isLast = index === messages.length - 1;
@@ -309,13 +308,15 @@ export function ChatMessagesView({
               </div>
             )}
         </div>
-      </ScrollArea>
-      <InputForm
-        onSubmit={onSubmit}
-        isLoading={isLoading}
-        onCancel={onCancel}
-        hasHistory={messages.length > 0}
-      />
+      </div>
+      <div className="bg-neutral-800 border-t border-neutral-700">
+        <InputForm
+          onSubmit={onSubmit}
+          isLoading={isLoading}
+          onCancel={onCancel}
+          hasHistory={messages.length > 0}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

This PR fixes the scrolling issues in the chat UI where the body element was stuck at 100vh height, causing content to scroll within a constrained container instead of naturally expanding.

## Problem

- Body height was fixed at 100vh with internal scrolling
- UI was buggy when content exceeded viewport height
- ScrollArea component was creating nested scrolling contexts
- Content was hidden behind fixed-positioned InputForm

## Solution

- Replaced ScrollArea component with native `overflow-y-auto`
- Implemented proper flexbox layout with `h-screen` on root container
- Moved InputForm from fixed positioning to normal document flow
- Used `useRef` for React-idiomatic scroll control instead of `document.querySelector`
- Removed unnecessary wrapper divs and `overflow-hidden` constraints

## Changes

### App.tsx
- Removed ScrollArea viewport query logic
- Simplified component structure by removing wrapper div
- Updated scroll logic to use ref directly

### ChatMessagesView.tsx
- Removed ScrollArea component import and usage
- Added `flex-1 overflow-y-auto` to chat messages container
- Placed InputForm in normal flow with border separator

## Screenshots

### Before
![](https://github.com/user-attachments/assets/26f907de-660b-4dd8-9005-8957960f0d1d)

### After
![](https://github.com/user-attachments/assets/4e55c204-afa9-4a0f-8cef-cd98571be8e8)


## Testing

- [x] Tested with long chat conversations
- [x] Verified scroll-to-bottom behavior on new messages
- [x] Confirmed InputForm stays visible at bottom
- [x] Checked responsive behavior on different screen sizes

## Related Issues

Fixes #[issue-number] (if applicable)
