### PR TITLE
fix(agent): Prevent AttributeError for reasoning model config

### DIFF
--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -39,6 +39,13 @@ class Configuration(BaseModel):
         metadata={"description": "The maximum number of research loops to perform."},
     )
 
+    reasoning_model: str = Field(
+        default="gemini-2.5-flash-preview-04-17",
+        metadata={
+            "description": "The name of the language model to use for the agent's reasoning."
+        },
+    )
+
     @classmethod
     def from_runnable_config(
         cls, config: Optional[RunnableConfig] = None


### PR DESCRIPTION
### Problem/Issue
Previously, accessing `configurable.reasoning_model` within the agent's graph logic, specifically in `backend/src/agent/graph.py`, could lead to an `AttributeError` if the `reasoning_model` field was not explicitly defined in the `Configuration` class. This could occur in scenarios where the configuration was initialized without this specific field being present or properly set.

The problematic line was:
```python
# backend/src/agent/graph.py
reasoning_model = state.get("reasoning_model") or configurable.reasoning_model
```

### Solution/Changes
This PR introduces the `reasoning_model` field to the `backend/src/agent/configuration.py` file's `Configuration` class.

```python
# backend/src/agent/configuration.py
class Configuration(BaseModel):
    # ... existing code ...
    reasoning_model: str = Field(
        default="gemini-2.5-flash-preview-04-17",
        metadata={
            "description": "The name of the language model to use for the agent's reasoning."
        },
    )
    # ... existing code ...
```

By adding this field with a sensible default value (`"gemini-2.5-flash-preview-04-17"`), we ensure that `configurable.reasoning_model` always references a valid string value, thus preventing the potential `AttributeError` at the point of access in `graph.py`.

### Benefits
*   **Prevents `AttributeError`**: Eliminates the potential runtime error when `configurable.reasoning_model` is accessed in `backend/src/agent/graph.py`.
*   **Enhances Robustness**: Makes the agent's configuration more robust by ensuring all expected model fields are defined.
*   **Improves Clarity**: Clearly defines the model used for agent reasoning within the central configuration.

### How to test
No specific testing steps are required beyond standard unit/integration tests for the agent, as this is a configuration addition designed to prevent a potential error rather than fix a known, reproducible bug in existing functionality. The change ensures the expected attribute is always present.