### PR TITLE
feat: Add landing page for application description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project demonstrates a fullstack application using a React frontend and a L
 ## Features
 
 - 💬 Fullstack application with a React frontend and LangGraph backend.
+- ląd User-friendly landing page available at `frontend/public/index.html` to get an overview of the quickstart. Open this file in your browser to view it.
 - 🧠 Powered by a LangGraph agent for advanced research and conversational AI.
 - 🔍 Dynamic search query generation using Google Gemini models.
 - 🌐 Integrated web research via Google Search API.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fullstack Agents with Gemini 1.5 and LangGraph</title>
+    <link rel="stylesheet" href="styles/style.css">
+</head>
+<body>
+    <header>
+        <h1>Fullstack Agents with Gemini 1.5 and LangGraph</h1>
+        <p>Quickstart to build your own AI-powered applications.</p>
+    </header>
+    <main>
+        <section id="overview">
+            <h2>Overview</h2>
+            <p>This project provides a comprehensive starting point for developing fullstack applications that leverage the power of Google's Gemini 1.5 model and LangGraph for creating complex, stateful AI agents. Explore the possibilities of building intelligent applications with a robust backend and a reactive frontend.</p>
+        </section>
+        <section id="features">
+            <h2>Key Features</h2>
+            <ul>
+                <li>Leverages Gemini 1.5 for advanced multimodal AI tasks.</li>
+                <li>Uses LangGraph for building stateful, multi-actor applications and agentic workflows.</li>
+                <li>Includes a quickstart setup for both frontend (React) and backend (Python/Flask) components.</li>
+                <li>Designed for easy extension and customization.</li>
+            </ul>
+        </section>
+        <section id="cta">
+            <h2>Get Started</h2>
+            <p>Explore the code and start building your own AI agents today!</p>
+            <a href="https://github.com/bigbangssm/gemini-fullstack-langgraph-quickstart" class="button">View on GitHub</a>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Your Project Name</p>
+    </footer>
+</body>
+</html>

--- a/frontend/public/styles/style.css
+++ b/frontend/public/styles/style.css
@@ -1,0 +1,73 @@
+body {
+    font-family: sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem 0;
+    text-align: center;
+}
+
+header h1 {
+    margin-bottom: 0.5rem;
+}
+
+header p {
+    margin-top: 0;
+    font-size: 1.1rem;
+}
+
+main {
+    padding: 20px;
+    max-width: 800px;
+    margin: 20px auto;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+section {
+    margin-bottom: 20px;
+}
+
+h2 {
+    color: #333;
+    border-bottom: 1px solid #eee;
+    padding-bottom: 0.5rem;
+}
+
+ul {
+    list-style: disc;
+    padding-left: 20px;
+}
+
+.button {
+    display: inline-block;
+    background-color: #007bff;
+    color: #fff;
+    padding: 10px 15px;
+    text-decoration: none;
+    border-radius: 5px;
+    font-weight: bold;
+}
+
+.button:hover {
+    background-color: #0056b3;
+}
+
+footer {
+    text-align: center;
+    padding: 1rem 0;
+    background-color: #333;
+    color: #fff;
+    position: relative; /* Changed from absolute to relative for better flow */
+    bottom: 0;
+    width: 100%;
+    margin-top: 20px; /* Added margin-top to prevent overlap */
+}


### PR DESCRIPTION
This commit introduces a new landing page for the application.

The landing page (`frontend/public/index.html`) provides:
- An overview of the "Fullstack Agents with Gemini 1.5 and LangGraph" quickstart.
- Key features of the template.
- A call to action button linking to the GitHub repository.

Basic styling is included (`frontend/public/styles/style.css`) for readability.

The README.md has also been updated to reference this new landing page.