### PR TITLE
docs: Update Python version requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Follow these steps to get the application running locally for development and te
 **1. Prerequisites:**
 
 -   Node.js and npm (or yarn/pnpm)
--   Python 3.8+
+-   Python 3.11+
 -   **`GEMINI_API_KEY`**: The backend agent requires a Google Gemini API key.
     1.  Navigate to the `backend/` directory.
     2.  Create a file named `.env` by copying the `backend/.env.example` file.


### PR DESCRIPTION
## Summary
- Updated README.md to correctly state Python 3.11+ requirement instead of Python 3.8+
- Aligns documentation with backend/pyproject.toml which requires Python >=3.11

## Problem
Users attempting to install the backend with Python 3.8-3.10 encountered errors:
```
ERROR: Package 'agent' requires a different Python: 3.10.16 not in '<4.0,>=3.11'
```

## Solution
Changed the Python version requirement in README.md from "Python 3.8+" to "Python 3.11+" to match the actual requirement in pyproject.toml.

Fixes #27