### PR TITLE
fix: AttributeError: 'Configuration' object has no attribute 'reasoning_model'

### DIFF
--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -153,7 +153,7 @@ def reflection(state: OverallState, config: RunnableConfig) -> ReflectionState:
     configurable = Configuration.from_runnable_config(config)
     # Increment the research loop count and get the reasoning model
     state["research_loop_count"] = state.get("research_loop_count", 0) + 1
-    reasoning_model = state.get("reasoning_model") or configurable.reasoning_model
+    reflection_model = state.get("reflection_model") or configurable.reflection_model
 
     # Format the prompt
     current_date = get_current_date()
@@ -162,9 +162,9 @@ def reflection(state: OverallState, config: RunnableConfig) -> ReflectionState:
         research_topic=get_research_topic(state["messages"]),
         summaries="\n\n---\n\n".join(state["web_research_result"]),
     )
-    # init Reasoning Model
+    # init Reflection Model
     llm = ChatGoogleGenerativeAI(
-        model=reasoning_model,
+        model=reflection_model,
         temperature=1.0,
         max_retries=2,
         api_key=os.getenv("GEMINI_API_KEY"),
@@ -231,7 +231,7 @@ def finalize_answer(state: OverallState, config: RunnableConfig):
         Dictionary with state update, including running_summary key containing the formatted final summary with sources
     """
     configurable = Configuration.from_runnable_config(config)
-    reasoning_model = state.get("reasoning_model") or configurable.reasoning_model
+    answer_model = state.get("answer_model") or configurable.answer_model
 
     # Format the prompt
     current_date = get_current_date()
@@ -241,9 +241,9 @@ def finalize_answer(state: OverallState, config: RunnableConfig):
         summaries="\n---\n\n".join(state["web_research_result"]),
     )
 
-    # init Reasoning Model, default to Gemini 2.5 Flash
+    # init Answer Model, default to Gemini 2.5 Pro
     llm = ChatGoogleGenerativeAI(
-        model=reasoning_model,
+        model=answer_model,
         temperature=0,
         max_retries=2,
         api_key=os.getenv("GEMINI_API_KEY"),


### PR DESCRIPTION
### Description
This PR fixes the incorrect access of attribute `reasoning_model` in `Configuration` class.

### Problem
In backend/src/agent/graph.py line 156(`reflection`) and line 234(`finalize_answer`),
```
reasoning_model = state.get("reasoning_model") or configurable.reasoning_model
```
raise the following error:
```
AttributeError: 'Configuration' object has no attribute 'reasoning_model'
```

### Solution
In the `reflection` function, change `reasoning_model` to `reflection_model`;  
in the `finalize_answer` function, change `reasoning_model` to `answer_model`.

### Changes
`graph.py` line 156 and line 234

### Impact
- [x] Fix runtime error when calling the reflection module and producing final output

### Test
Place the following Python script in `backend/src` to test:
```
import sys
from dotenv import load_dotenv
from langchain_core.messages import BaseMessage, AIMessage
from agent.graph import graph

def main():
    load_dotenv()

    user_query = "What is Internet?"

    init_state = {
        "messages": [BaseMessage(type='text', content=user_query)],
    }

    result_state = graph.invoke(init_state)

    msgs = result_state.get("messages", [])
    if not msgs:
        print("No answer was generated.")
        sys.exit(1)

    last_ai: AIMessage = msgs[-1]
    print("Output:\n")
    print(last_ai.content)

if __name__ == "__main__":
    main()
```

### Related Issues
Fixes #12, #34