### PR TITLE
Add CLI script to run LangGraph research agent (cli_research.py)

### DIFF
--- a/backend/examples/cli_research.py
+++ b/backend/examples/cli_research.py
@@ -1,0 +1,43 @@
+import argparse
+from langchain_core.messages import HumanMessage
+from agent.graph import graph
+
+
+def main() -> None:
+    """Run the research agent from the command line."""
+    parser = argparse.ArgumentParser(description="Run the LangGraph research agent")
+    parser.add_argument("question", help="Research question")
+    parser.add_argument(
+        "--initial-queries",
+        type=int,
+        default=3,
+        help="Number of initial search queries",
+    )
+    parser.add_argument(
+        "--max-loops",
+        type=int,
+        default=2,
+        help="Maximum number of research loops",
+    )
+    parser.add_argument(
+        "--reasoning-model",
+        default="gemini-2.5-pro-preview-05-06",
+        help="Model for the final answer",
+    )
+    args = parser.parse_args()
+
+    state = {
+        "messages": [HumanMessage(content=args.question)],
+        "initial_search_query_count": args.initial_queries,
+        "max_research_loops": args.max_loops,
+        "reasoning_model": args.reasoning_model,
+    }
+
+    result = graph.invoke(state)
+    messages = result.get("messages", [])
+    if messages:
+        print(messages[-1].content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This PR adds a command-line interface (CLI) script under `backend/examples/cli_research.py` that allows users to run the LangGraph-based research agent directly from the terminal — without spinning up the full frontend/backend stack.

---

### How to Use

Run a research query from the command line:

```bash
cd backend
python examples/cli_research.py "What are the latest trends in renewable energy?"
