### PR TITLE
feat: allow you to customize research depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project demonstrates a fullstack application using a React frontend and a L
 - 🔍 Dynamic search query generation using Google Gemini models.
 - 🌐 Integrated web research via Google Search API.
 - 🤔 Reflective reasoning to identify knowledge gaps and refine searches.
+- ⚙️ Customizable research depth: Allows users to specify the number of initial search queries and maximum research loops.
 - 📄 Generates answers with citations from gathered sources.
 - 🔄 Hot-reloading for both frontend and backend development during development.
 

--- a/backend/src/agent/state.py
+++ b/backend/src/agent/state.py
@@ -17,8 +17,8 @@ class OverallState(TypedDict):
     search_query: Annotated[list, operator.add]
     web_research_result: Annotated[list, operator.add]
     sources_gathered: Annotated[list, operator.add]
-    initial_search_query_count: int
-    max_research_loops: int
+    initial_search_query_count: NotRequired[int]
+    max_research_loops: NotRequired[int]
     research_loop_count: int
     reasoning_model: str
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5438,7 +5438,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,30 +103,54 @@ export default function App() {
   }, [thread.messages, thread.isLoading, processedEventsTimeline]);
 
   const handleSubmit = useCallback(
-    (submittedInputValue: string, effort: string, model: string) => {
+    (
+      submittedInputValue: string,
+      effort: string,
+      model: string,
+      numSearchQueries?: string,
+      maxResearchLoops?: string
+    ) => {
       if (!submittedInputValue.trim()) return;
       setProcessedEventsTimeline([]);
       hasFinalizeEventOccurredRef.current = false;
 
-      // convert effort to, initial_search_query_count and max_research_loops
-      // low means max 1 loop and 1 query
-      // medium means max 3 loops and 3 queries
-      // high means max 10 loops and 5 queries
       let initial_search_query_count = 0;
       let max_research_loops = 0;
-      switch (effort) {
-        case "low":
-          initial_search_query_count = 1;
-          max_research_loops = 1;
-          break;
-        case "medium":
-          initial_search_query_count = 3;
-          max_research_loops = 3;
-          break;
-        case "high":
-          initial_search_query_count = 5;
-          max_research_loops = 10;
-          break;
+
+      const parsedNumSearchQueries = numSearchQueries
+        ? parseInt(numSearchQueries, 10)
+        : NaN;
+      const parsedMaxResearchLoops = maxResearchLoops
+        ? parseInt(maxResearchLoops, 10)
+        : NaN;
+
+      if (
+        !isNaN(parsedNumSearchQueries) &&
+        parsedNumSearchQueries > 0 &&
+        !isNaN(parsedMaxResearchLoops) &&
+        parsedMaxResearchLoops > 0
+      ) {
+        initial_search_query_count = parsedNumSearchQueries;
+        max_research_loops = parsedMaxResearchLoops;
+      } else {
+        // Fallback to effort-based calculation
+        // low means max 1 loop and 1 query
+        // medium means max 3 loops and 3 queries
+        // high means max 10 loops and 5 queries
+        switch (effort) {
+          case "low":
+            initial_search_query_count = 1;
+            max_research_loops = 1;
+            break;
+          case "medium":
+            initial_search_query_count = 3;
+            max_research_loops = 3;
+            break;
+          case "high":
+            initial_search_query_count = 5;
+            max_research_loops = 10;
+            break;
+        }
       }
 
       const newMessages: Message[] = [

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { SquarePen, Brain, Send, StopCircle, Zap, Cpu } from "lucide-react";
+import { SquarePen, Brain, Send, StopCircle, Zap, Cpu, Search, Repeat } from "lucide-react";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -12,7 +13,13 @@ import {
 
 // Updated InputFormProps
 interface InputFormProps {
-  onSubmit: (inputValue: string, effort: string, model: string) => void;
+  onSubmit: (
+    inputValue: string,
+    effort: string,
+    model: string,
+    numSearchQueries?: string,
+    maxResearchLoops?: string
+  ) => void;
   onCancel: () => void;
   isLoading: boolean;
   hasHistory: boolean;
@@ -27,11 +34,19 @@ export const InputForm: React.FC<InputFormProps> = ({
   const [internalInputValue, setInternalInputValue] = useState("");
   const [effort, setEffort] = useState("medium");
   const [model, setModel] = useState("gemini-2.5-flash-preview-04-17");
+  const [numSearchQueries, setNumSearchQueries] = useState("3");
+  const [maxResearchLoops, setMaxResearchLoops] = useState("3");
 
   const handleInternalSubmit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (!internalInputValue.trim()) return;
-    onSubmit(internalInputValue, effort, model);
+    onSubmit(
+      internalInputValue,
+      effort,
+      model,
+      numSearchQueries,
+      maxResearchLoops
+    );
     setInternalInputValue("");
   };
 
@@ -125,6 +140,32 @@ export const InputForm: React.FC<InputFormProps> = ({
                 </SelectItem>
               </SelectContent>
             </Select>
+          </div>
+          <div className="flex flex-row gap-2 bg-neutral-700 border-neutral-600 text-neutral-300 focus:ring-neutral-500 rounded-xl rounded-t-sm pl-2 max-w-[100%] sm:max-w-[90%]">
+            <div className="flex flex-row items-center text-sm">
+              <Search className="h-4 w-4 mr-2" />
+              Search Queries
+            </div>
+            <Input
+              type="number"
+              value={numSearchQueries}
+              onChange={(e) => setNumSearchQueries(e.target.value)}
+              placeholder="3"
+              className="w-[60px] bg-transparent border-none focus:outline-none focus:ring-0 outline-none focus-visible:ring-0 shadow-none text-neutral-100 placeholder-neutral-500"
+            />
+          </div>
+          <div className="flex flex-row gap-2 bg-neutral-700 border-neutral-600 text-neutral-300 focus:ring-neutral-500 rounded-xl rounded-t-sm pl-2 max-w-[100%] sm:max-w-[90%]">
+            <div className="flex flex-row items-center text-sm">
+              <Repeat className="h-4 w-4 mr-2" />
+              Research Loops
+            </div>
+            <Input
+              type="number"
+              value={maxResearchLoops}
+              onChange={(e) => setMaxResearchLoops(e.target.value)}
+              placeholder="3"
+              className="w-[60px] bg-transparent border-none focus:outline-none focus:ring-0 outline-none focus-visible:ring-0 shadow-none text-neutral-100 placeholder-neutral-500"
+            />
           </div>
           <div className="flex flex-row gap-2 bg-neutral-700 border-neutral-600 text-neutral-300 focus:ring-neutral-500 rounded-xl rounded-t-sm pl-2  max-w-[100%] sm:max-w-[90%]">
             <div className="flex flex-row items-center text-sm ml-2">


### PR DESCRIPTION
this commit introduces a new feature that allows you to specify the number of initial search queries and the maximum number of research loops.

modifications:

- frontend:
    - added input fields in `ınputform.tsx` for "number of search queries" and "max research loops".
    - updated `app.tsx` to pass these values to the backend, with a fallback to the existing "effort" level logic if the new fields are not filled or contain invalid input.
- backend:
    - updated `state.py` to make `initial_search_query_count` and `max_research_loops` in `overallstate` optional.
    - modified `graph.py` so that the `generate_query` node and `evaluate_research` conditional edge use these values you provide if available and valid, otherwise defaulting to configuration-based values.
- documentation:
    - updated `readme.md` to mention the new customization feature.