### PR TITLE
Update prompts.py

### DIFF
--- a/backend/src/agent/prompts.py
+++ b/backend/src/agent/prompts.py
@@ -17,7 +17,7 @@ Instructions:
 - Query should ensure that the most current information is gathered. The current date is {current_date}.
 
 Format: 
-- Format your response as a JSON object with ALL three of these exact keys:
+- Format your response as a JSON object with ALL two of these exact keys:
    - "rationale": Brief explanation of why these queries are relevant
    - "query": A list of search queries
 


### PR DESCRIPTION
Changed the prompt as, earlier it was mentioned about 3 keys of json object in "query_writer_instructions"

Before: The prompt said "three keys", but only two (rationale, query) were ever expected or processed.

After: It’s now clear that only two keys are required.

📌 Why it matters: Prevents confusion for developers reading or maintaining the code, especially when onboarding or contributing.