### PR TITLE
Fix: Handle undefined properties in onUpdateEvent to prevent streaming crashes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,9 +32,10 @@ export default function App() {
     onUpdateEvent: (event: any) => {
       let processedEvent: ProcessedEvent | null = null;
       if (event.generate_query) {
+        const queryList = event.generate_query.query_list || [];
         processedEvent = {
           title: "Generating Search Queries",
-          data: event.generate_query.query_list.join(", "),
+          data: queryList.join(", "),
         };
       } else if (event.web_research) {
         const sources = event.web_research.sources_gathered || [];
@@ -54,7 +55,7 @@ export default function App() {
           title: "Reflection",
           data: event.reflection.is_sufficient
             ? "Search successful, generating final answer."
-            : `Need more information, searching for ${event.reflection.follow_up_queries.join(
+            : `Need more information, searching for ${(event.reflection.follow_up_queries || []).join(
                 ", "
               )}`,
         };

--- a/frontend/src/components/ChatMessagesView.tsx
+++ b/frontend/src/components/ChatMessagesView.tsx
@@ -196,11 +196,18 @@ const AiMessageBubble: React.FC<AiMessageBubbleProps> = ({
           />
         </div>
       )}
-      <ReactMarkdown components={mdComponents}>
-        {typeof message.content === "string"
-          ? message.content
-          : JSON.stringify(message.content)}
-      </ReactMarkdown>
+      {/* Only render markdown if we have content */}
+      {message.content && (typeof message.content === "string" ? message.content.trim() : true) ? (
+        <ReactMarkdown components={mdComponents}>
+          {typeof message.content === "string"
+            ? message.content
+            : JSON.stringify(message.content)}
+        </ReactMarkdown>
+      ) : (
+        <div className="text-neutral-400 italic">
+          {isLiveActivityForThisBubble ? "Processing..." : "No response received"}
+        </div>
+      )}
       <Button
         variant="default"
         className="cursor-pointer bg-neutral-700 border-neutral-600 text-neutral-300 self-end"


### PR DESCRIPTION
## Problem
The frontend streaming would crash when `event.generate_query.query_list` or `event.reflection.follow_up_queries` were undefined, causing a TypeError that broke the entire event processing pipeline. This resulted in the UI showing "No response received" even though the backend was working correctly and generating proper responses.

**Error occurred:**
TypeError: Cannot read properties of undefined (reading 'join')


This prevented the `finalize_answer` event from being processed, leaving users with empty AI responses despite successful backend processing.
