### PR TITLE
update query_writer_instructions format prompt

### DIFF
--- a/backend/src/agent/prompts.py
+++ b/backend/src/agent/prompts.py
@@ -17,7 +17,7 @@ Instructions:
 - Query should ensure that the most current information is gathered. The current date is {current_date}.
 
 Format: 
-- Format your response as a JSON object with ALL three of these exact keys:
+- Format your response as a JSON object with these exact keys:
    - "rationale": Brief explanation of why these queries are relevant
    - "query": A list of search queries
 


### PR DESCRIPTION
It includes a modification to the prompt to better adjust for the expected output.

Format: 
- Format your response as a JSON object with ~ALL three of~ these exact keys:
   - "rationale": Brief explanation of why these queries are relevant
   - "query": A list of search queries