### PR TITLE
Fix: Type checks in event handler to prevent UI errors and ensure AI …

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,7 +34,9 @@ export default function App() {
       if (event.generate_query) {
         processedEvent = {
           title: "Generating Search Queries",
-          data: event.generate_query.query_list.join(", "),
+          data: Array.isArray(event.generate_query.query_list)
+            ? event.generate_query.query_list.join(", ")
+            : "",
         };
       } else if (event.web_research) {
         const sources = event.web_research.sources_gathered || [];
@@ -52,11 +54,13 @@ export default function App() {
       } else if (event.reflection) {
         processedEvent = {
           title: "Reflection",
-          data: event.reflection.is_sufficient
-            ? "Search successful, generating final answer."
-            : `Need more information, searching for ${event.reflection.follow_up_queries.join(
-                ", "
-              )}`,
+          data: Array.isArray(event.reflection.follow_up_queries)
+            ? (event.reflection.is_sufficient
+                ? "Search successful, generating final answer."
+                : `Need more information, searching for ${event.reflection.follow_up_queries.join(", ")}`)
+            : (event.reflection.is_sufficient
+                ? "Search successful, generating final answer."
+                : "Need more information, searching for follow up queries."),
         };
       } else if (event.finalize_answer) {
         processedEvent = {

--- a/frontend/src/components/ChatMessagesView.tsx
+++ b/frontend/src/components/ChatMessagesView.tsx
@@ -239,6 +239,7 @@ export function ChatMessagesView({
   liveActivityEvents,
   historicalActivities,
 }: ChatMessagesViewProps) {
+  console.log("[DEBUG] Messages in ChatMessagesView:", messages); // Debug log
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
 
   const handleCopy = async (text: string, messageId: string) => {


### PR DESCRIPTION
…messages display
The UI would not display AI messages if the backend response was missing or had undefined fields (e.g., follow_up_queries).
A TypeError (Cannot read properties of undefined (reading 'join')) in the event handler interrupted message processing, so only human messages appeared in the chat.