### PR TITLE
Bugfix: "hook.js:608 TypeError: Cannot read properties of undefined (…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,9 +54,9 @@ export default function App() {
           title: "Reflection",
           data: event.reflection.is_sufficient
             ? "Search successful, generating final answer."
-            : `Need more information, searching for ${event.reflection.follow_up_queries.join(
+            : `Need more information, searching for ${event.reflection.follow_up_queries?.join(
                 ", "
-              )}`,
+              ) || "additional queries"}`,
         };
       } else if (event.finalize_answer) {
         processedEvent = {


### PR DESCRIPTION
Fix TypeError in App.tsx onUpdateEvent handler

- Added optional chaining to prevent crash when `follow_up_queries` is undefined
- Added fallback text "additional queries" when the array is not available
- Resolves TypeError: Cannot read properties of undefined (reading 'join')