### PR TITLE
feat: Implement frontend LLM configuration UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,74 @@ The core of the backend is a LangGraph agent defined in `backend/src/agent/graph
 4.  **Iterative Refinement:** If gaps are found or the information is insufficient, it generates follow-up queries and repeats the web research and reflection steps (up to a configured maximum number of loops).
 5.  **Finalize Answer:** Once the research is deemed sufficient, the agent synthesizes the gathered information into a coherent answer, including citations from the web sources, using a Gemini model.
 
+## LLM Provider Configuration
+
+The backend agent can be configured to use different Large Language Model (LLM) providers beyond the default Google Gemini. This allows for flexibility in choosing models, including locally run models via Ollama or LM Studio.
+
+The following environment variables control the LLM provider. These are typically set in your `docker-compose.yml` for containerized deployments, or can be set as system environment variables if running the backend directly. For local development without Docker, you might need to ensure your Python execution environment loads these (e.g., via a `.env` file that your application explicitly loads for these settings).
+
+-   **`LLM_PROVIDER`**:
+    *   **Description**: Specifies the LLM provider to use for the agent's core reasoning, query generation, and answer synthesis.
+    *   **Values**: `"gemini"`, `"ollama"`, `"lmstudio"`
+    *   **Default**: `"gemini"` (as set in `docker-compose.yml`)
+    *   **Note**: When using `ollama` or `lmstudio`, ensure the respective services are running and accessible.
+
+-   **`OLLAMA_BASE_URL`**:
+    *   **Description**: The base URL for the Ollama API if `LLM_PROVIDER` is set to `"ollama"`.
+    *   **Default**: `"http://host.docker.internal:11434"` (as set in `docker-compose.yml`, points to the host machine from within Docker)
+    *   **Note**: If running Ollama on a different host or port, or running the backend outside Docker, adjust this value accordingly (e.g., `http://localhost:11434`).
+
+-   **`OLLAMA_MODEL_NAME`**:
+    *   **Description**: The model name to use with Ollama (e.g., "llama2", "mistral", "codellama").
+    *   **Default**: `"llama2"` (as set in `docker-compose.yml`)
+    *   **Note**: The specified model must be pulled and available in your Ollama instance.
+
+-   **`LMSTUDIO_BASE_URL`**:
+    *   **Description**: The base URL for the LM Studio compatible API if `LLM_PROVIDER` is set to `"lmstudio"`. This usually ends with `/v1`.
+    *   **Default**: `"http://host.docker.internal:1234/v1"` (as set in `docker-compose.yml`, points to the host machine from within Docker)
+    *   **Note**: If running LM Studio on a different host or port, or running the backend outside Docker, adjust this value accordingly (e.g., `http://localhost:1234/v1`).
+
+-   **`LMSTUDIO_MODEL_NAME`**:
+    *   **Description**: The model identifier to use with LM Studio. This can often be found in the LM Studio UI (e.g., "Publisher/Repository/ModelFile").
+    *   **Default**: `"local-model"` (as set in `docker-compose.yml`; this is a generic placeholder and should be updated to a specific model identifier loaded in your LM Studio).
+
+### Important Notes for Ollama and LM Studio Usage:
+
+*   **Accessibility**: When running the application with Docker, `host.docker.internal` is used as the default hostname in `docker-compose.yml` to allow the Docker container to access services (Ollama, LM Studio) running on your host machine. If these services are running elsewhere (e.g., a different machine on your network), update the `*_BASE_URL` in your `docker-compose.yml` or environment configuration.
+*   **Model Compatibility**: The models selected in Ollama or LM Studio should ideally be instruction-following chat models. While the system attempts to use them for tasks like query generation and reflection, their performance and ability to adhere to specific output formats (like structured output for search queries or reflection steps) may vary significantly compared to Gemini. Some models may not support the required function calling or structured output capabilities effectively.
+*   **Current Limitation - Web Research**: The integrated web research capability, which utilizes Google Search tools directly via Gemini models, is **only functional when `LLM_PROVIDER` is set to `"gemini"`**. If you select "ollama" or "lmstudio", the agent will still attempt to generate search queries and reflect on content (if any were hypothetically provided), but it will **not** be able to perform actual web searches or incorporate real-time web content into its answers. This is because the Google Search tool integration is currently specific to the Gemini models used in this application.
+
+### Configuring via the User Interface
+
+In addition to setting environment variables, you can now configure LLM provider settings directly within the application's user interface.
+
+*   **Accessing Configuration:** Click the **gear icon (⚙️)** usually found in the header of the application to open the LLM Configuration modal.
+*   **Available Settings:**
+    *   **LLM Provider:** Select between "Gemini", "Ollama", and "LM Studio".
+    *   **Gemini API Key:** Input your Gemini API key when "Gemini" is selected. This is stored in your browser's local storage and sent with each request.
+    *   **Ollama Settings:** Configure the Base URL (e.g., `http://localhost:11434`) and the Model Name (e.g., `llama2`) when "Ollama" is selected.
+    *   **LM Studio Settings:** Configure the Base URL (e.g., `http://localhost:1234/v1`) and the Model Name when "LM Studio" is selected.
+*   **Automatic Saving:** Changes made in the UI are automatically saved to your browser's local storage and applied to subsequent requests.
+
+#### Configuration Precedence
+
+The application uses the following order to determine which configuration values to apply for each agent request:
+
+1.  **UI Configuration (Local Storage):** Settings configured and saved via the user interface take the highest precedence. These are sent with each request to the backend.
+2.  **Environment Variables:** If a specific setting is not configured in the UI (or if local storage is empty/cleared, or the UI sends a `null` value for a field), the backend application will fall back to using the environment variables defined for it (e.g., in `docker-compose.yml` or the system environment). This includes `GEMINI_API_KEY` (for chat models and the initial default for the UI), `LLM_PROVIDER`, `OLLAMA_BASE_URL`, etc.
+3.  **Application Defaults (Backend):** If a setting is not found in either the UI's local storage (and thus not sent in the request) nor in the environment variables, the backend application will rely on its built-in default values (defined in the Pydantic model fields in `backend/src/agent/configuration.py`). For critical settings like API keys or base URLs, if no value is provided by any layer, this may lead to errors or non-functional behavior for the selected provider.
+
+#### Resetting to Defaults
+
+*   The configuration modal includes a **"Reset to Defaults"** button.
+*   Clicking this button will:
+    1.  Clear any LLM settings currently stored in your browser's local storage.
+    2.  Fetch and apply the default configuration currently exposed by the backend via its `/agent/config-defaults` endpoint. These backend-provided defaults are themselves determined by the environment variables set at the time the backend starts, plus any hardcoded application defaults.
+*   This is useful if you want to revert to the baseline environment configuration or resolve issues caused by incorrect UI settings.
+
+**Note on `GEMINI_API_KEY` for Web Research:**
+As highlighted in the "Important Notes" and within the UI itself, the web research capability (which uses Google Search tools via the `google.generai.Client`) currently relies on a `GEMINI_API_KEY` set as an **environment variable** when the backend application starts. It does **not** use the Gemini API key that might be configured via the UI for this specific web search functionality. Other Gemini-powered chat, reasoning, and query generation steps **will** use the UI-configured (or environment-fallback) Gemini API key.
+
 ## Deployment
 
 In production, the backend server serves the optimized static frontend build. LangGraph requires a Redis instance and a Postgres database. Redis is used as a pub-sub broker to enable streaming real time output from background runs. Postgres is used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. For more details on how to deploy the backend server, take a look at the [LangGraph Documentation](https://langchain-ai.github.io/langgraph/concepts/deployment_options/). Below is an example of how to build a Docker image that includes the optimized frontend build and the backend server and run it via `docker-compose`.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,11 +18,13 @@ dependencies = [
     "langgraph-api",
     "fastapi",
     "google-genai",
+    "langchain-community>=0.0.38, <0.1.0",
 ]
 
 
 [project.optional-dependencies]
 dev = ["mypy>=1.11.1", "ruff>=0.6.1"]
+test = ["pytest>=8.3.5", "pytest-mock>=3.0.0"]
 
 [build-system]
 requires = ["setuptools>=73.0.0", "wheel"]
@@ -56,4 +58,5 @@ convention = "google"
 dev = [
     "langgraph-cli[inmem]>=0.1.71",
     "pytest>=8.3.5",
+    "pytest-mock>=3.0.0",
 ]

--- a/backend/src/agent/app.py
+++ b/backend/src/agent/app.py
@@ -3,6 +3,9 @@ import pathlib
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 
+from agent.configuration import Configuration
+from langchain_core.runnables import RunnableConfig # For type hinting or if we pass None
+
 # Define the FastAPI app
 app = FastAPI()
 
@@ -43,3 +46,21 @@ app.mount(
     create_frontend_router(),
     name="frontend",
 )
+
+
+@app.get("/agent/config-defaults", response_model_exclude_none=True)
+async def get_config_defaults():
+    """
+    Returns the default agent configuration based on environment variables
+    and Pydantic model defaults. This represents the configuration the agent
+    would use if no specific runtime configuration is provided for a request.
+    """
+    # Pass an empty 'configurable' dict to from_runnable_config.
+    # This ensures that only environment variables and Pydantic defaults are used.
+    # If None is passed, it defaults to an empty dict anyway.
+    run_config_for_defaults: RunnableConfig = {"configurable": {}}
+    default_config = Configuration.from_runnable_config(run_config_for_defaults)
+
+    # model_dump() is Pydantic v2, dict() was for v1.
+    # response_model_exclude_none=True in @app.get will handle not sending None values.
+    return default_config.model_dump()

--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -1,12 +1,51 @@
 import os
+from enum import Enum
 from pydantic import BaseModel, Field
 from typing import Any, Optional
 
 from langchain_core.runnables import RunnableConfig
 
 
+class LLMProvider(str, Enum):
+    """The available LLM providers."""
+
+    GEMINI = "gemini"
+    OLLAMA = "ollama"
+    LMSTUDIO = "lmstudio"
+
+
 class Configuration(BaseModel):
     """The configuration for the agent."""
+
+    gemini_api_key: Optional[str] = Field(
+        default=None,
+        metadata={"description": "The API key for Google Gemini services."},
+    )
+
+    llm_provider: LLMProvider = Field(
+        default=LLMProvider.GEMINI,
+        metadata={"description": "The LLM provider to use."},
+    )
+
+    ollama_base_url: Optional[str] = Field(
+        default=None,
+        metadata={"description": "The base URL for the Ollama API."},
+    )
+
+    ollama_model_name: Optional[str] = Field(
+        default=None,
+        metadata={"description": "The model name to use with Ollama."},
+    )
+
+    lmstudio_base_url: Optional[str] = Field(
+        default=None,
+        metadata={"description": "The base URL for the LM Studio API."},
+    )
+
+    lmstudio_model_name: Optional[str] = Field(
+        default=None,
+        metadata={"description": "The model name to use with LM Studio."},
+    )
 
     query_generator_model: str = Field(
         default="gemini-2.0-flash",
@@ -48,13 +87,23 @@ class Configuration(BaseModel):
             config["configurable"] if config and "configurable" in config else {}
         )
 
-        # Get raw values from environment or config
-        raw_values: dict[str, Any] = {
-            name: os.environ.get(name.upper(), configurable.get(name))
-            for name in cls.model_fields.keys()
-        }
+        raw_values: dict[str, Any] = {}
+        for name, field_info in cls.model_fields.items():
+            # 1. Try to get value from 'configurable' (e.g., frontend request)
+            configurable_value = configurable.get(name)
 
-        # Filter out None values
-        values = {k: v for k, v in raw_values.items() if v is not None}
+            if configurable_value is not None:
+                raw_values[name] = configurable_value
+            else:
+                # 2. If not in 'configurable' or None, try to get from environment variables
+                #    The environment variable name is assumed to be the uppercase field name.
+                env_value = os.environ.get(name.upper())
+                if env_value is not None:
+                    raw_values[name] = env_value
+                # 3. If neither 'configurable' nor environment variable is set (or both are None),
+                #    the key is not added to raw_values. Pydantic will then use the
+                #    `default` value specified in `Field()` when `cls(**raw_values)` is called.
 
-        return cls(**values)
+        # Pydantic will handle type conversion for basic types.
+        # If a field is not present in raw_values, Pydantic uses its default.
+        return cls(**raw_values)

--- a/backend/src/agent/test_configuration.py
+++ b/backend/src/agent/test_configuration.py
@@ -1,0 +1,137 @@
+import os
+import pytest
+from unittest.mock import patch
+
+from agent.configuration import Configuration, LLMProvider
+
+
+@pytest.fixture(autouse=True)
+def clear_env_vars():
+    """Clear relevant environment variables before each test."""
+    vars_to_clear = [
+        "LLM_PROVIDER",
+        "OLLAMA_BASE_URL",
+        "OLLAMA_MODEL_NAME",
+        "LMSTUDIO_BASE_URL",
+        "LMSTUDIO_MODEL_NAME",
+        "QUERY_GENERATOR_MODEL", # Clear others to ensure defaults are tested
+        "REFLECTION_MODEL",
+        "ANSWER_MODEL",
+        "NUMBER_OF_INITIAL_QUERIES",
+        "MAX_RESEARCH_LOOPS",
+    ]
+    original_values = {var: os.environ.get(var) for var in vars_to_clear}
+    for var in vars_to_clear:
+        if os.environ.get(var) is not None:
+            del os.environ[var]
+    yield
+    for var, val in original_values.items():
+        if val is not None:
+            os.environ[var] = val
+        elif os.environ.get(var) is not None: # if it was set during test but not before
+            del os.environ[var]
+
+
+def test_from_runnable_config_defaults():
+    """Test that default values are loaded when no env vars are set."""
+    config = Configuration.from_runnable_config()
+
+    assert config.llm_provider == LLMProvider.GEMINI
+    assert config.ollama_base_url is None
+    assert config.ollama_model_name is None
+    assert config.lmstudio_base_url is None
+    assert config.lmstudio_model_name is None
+    assert config.query_generator_model == "gemini-2.0-flash" # Default from class
+    assert config.number_of_initial_queries == 3 # Default from class
+
+
+@patch.dict(os.environ, {
+    "LLM_PROVIDER": "ollama",
+    "OLLAMA_BASE_URL": "http://ollama:11434",
+    "OLLAMA_MODEL_NAME": "test-ollama-model",
+})
+def test_from_runnable_config_ollama_provider():
+    """Test loading Ollama provider configuration from environment variables."""
+    config = Configuration.from_runnable_config()
+
+    assert config.llm_provider == LLMProvider.OLLAMA
+    assert config.ollama_base_url == "http://ollama:11434"
+    assert config.ollama_model_name == "test-ollama-model"
+    assert config.lmstudio_base_url is None
+    assert config.lmstudio_model_name is None
+
+
+@patch.dict(os.environ, {
+    "LLM_PROVIDER": "lmstudio",
+    "LMSTUDIO_BASE_URL": "http://lmstudio:1234/v1",
+    "LMSTUDIO_MODEL_NAME": "test-lmstudio-model",
+})
+def test_from_runnable_config_lmstudio_provider():
+    """Test loading LM Studio provider configuration from environment variables."""
+    config = Configuration.from_runnable_config()
+
+    assert config.llm_provider == LLMProvider.LMSTUDIO
+    assert config.lmstudio_base_url == "http://lmstudio:1234/v1"
+    assert config.lmstudio_model_name == "test-lmstudio-model"
+    assert config.ollama_base_url is None
+    assert config.ollama_model_name is None
+
+
+@patch.dict(os.environ, {"LLM_PROVIDER": "invalid_provider"})
+def test_from_runnable_config_invalid_provider():
+    """Test handling of an invalid LLM provider value."""
+    # Pydantic should raise a ValidationError
+    with pytest.raises(ValueError): # Adjusted to ValueError based on Pydantic v2 behavior for Enums
+        Configuration.from_runnable_config()
+
+
+def test_from_runnable_config_gemini_defaults_explicit():
+    """Test that Gemini is default even if other LLM vars are partially set."""
+    # GEMINI is default, so no need to set LLM_PROVIDER
+    # Test that ollama/lmstudio fields are not populated if provider is gemini
+    with patch.dict(os.environ, {
+        "OLLAMA_BASE_URL": "http://shouldnotbeused:11434",
+        "LMSTUDIO_MODEL_NAME": "shouldnotbeusedeither",
+    }):
+        config = Configuration.from_runnable_config()
+        assert config.llm_provider == LLMProvider.GEMINI
+        assert config.ollama_base_url == "http://shouldnotbeused:11434" # Field will be set if env var is present
+        assert config.ollama_model_name is None
+        assert config.lmstudio_base_url is None
+        assert config.lmstudio_model_name == "shouldnotbeusedeither" # Field will be set
+
+
+def test_from_runnable_config_partial_ollama_still_loads_what_is_there():
+    """Test that if provider is ollama, but model name is missing, base_url is still loaded."""
+    with patch.dict(os.environ, {
+        "LLM_PROVIDER": "ollama",
+        "OLLAMA_BASE_URL": "http://partialollama:11434",
+    }):
+        config = Configuration.from_runnable_config()
+        assert config.llm_provider == LLMProvider.OLLAMA
+        assert config.ollama_base_url == "http://partialollama:11434"
+        assert config.ollama_model_name is None # Defaults to None
+
+
+def test_runnable_config_override():
+    """Test that runnable config values override environment variables."""
+    with patch.dict(os.environ, {
+        "LLM_PROVIDER": "gemini",
+        "OLLAMA_BASE_URL": "http://env_ollama:11434",
+        "OLLAMA_MODEL_NAME": "env_ollama_model",
+    }):
+        runnable_config_values = {
+            "llm_provider": "ollama",
+            "ollama_base_url": "http://runnable_ollama:11434",
+            "ollama_model_name": "runnable_ollama_model",
+            "lmstudio_base_url": "http://runnable_lmstudio:1234/v1",
+        }
+        config_input = {"configurable": runnable_config_values}
+
+        config = Configuration.from_runnable_config(config_input)
+
+        assert config.llm_provider == LLMProvider.OLLAMA
+        assert config.ollama_base_url == "http://runnable_ollama:11434"
+        assert config.ollama_model_name == "runnable_ollama_model"
+        assert config.lmstudio_base_url == "http://runnable_lmstudio:1234/v1"
+        assert config.lmstudio_model_name is None # Not in runnable_config_values, not in env

--- a/backend/src/agent/test_graph.py
+++ b/backend/src/agent/test_graph.py
@@ -1,0 +1,179 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Import the node function and relevant classes
+from agent.graph import generate_query
+from agent.configuration import Configuration, LLMProvider
+from agent.tools_and_schemas import SearchQueryList # For structured_llm mock
+
+# Mock initial state for the node
+mock_initial_state = {
+    "messages": [{"role": "user", "content": "Test question"}],
+    "initial_search_query_count": None, # To let the default from config apply
+}
+
+# Mock RunnableConfig (though Configuration.from_runnable_config will be patched)
+mock_runnable_config = {"configurable": {}}
+
+
+@patch("agent.graph.ChatGoogleGenerativeAI")
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_gemini_provider(mock_from_config, mock_chat_google):
+    """Test generate_query uses ChatGoogleGenerativeAI when provider is GEMINI."""
+    # Setup mock Configuration returned by from_runnable_config
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.GEMINI,
+        query_generator_model="gemini-test-model",
+        # other fields will use defaults from Configuration class
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    # Mock the structured_llm chain
+    mock_structured_llm = MagicMock()
+    mock_chat_google.return_value.with_structured_output.return_value = mock_structured_llm
+    mock_structured_llm.invoke.return_value = SearchQueryList(query=["Test query 1"])
+
+    # Call the node
+    result_state = generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+    # Assertions
+    mock_from_config.assert_called_once_with(mock_runnable_config)
+    mock_chat_google.assert_called_once_with(
+        model="gemini-test-model",
+        temperature=1.0,
+        max_retries=2,
+        api_key=None, # os.getenv("GEMINI_API_KEY") would be used, but it's None in tests unless set
+    )
+    mock_chat_google.return_value.with_structured_output.assert_called_once_with(SearchQueryList)
+    mock_structured_llm.invoke.assert_called_once()
+    assert result_state["query_list"] == ["Test query 1"]
+
+
+@patch("agent.graph.ChatOllama")
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_ollama_provider(mock_from_config, mock_chat_ollama):
+    """Test generate_query uses ChatOllama when provider is OLLAMA."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.OLLAMA,
+        ollama_base_url="http://ollama:11434",
+        ollama_model_name="ollama-test-model",
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    mock_structured_llm = MagicMock()
+    mock_chat_ollama.return_value.with_structured_output.return_value = mock_structured_llm
+    mock_structured_llm.invoke.return_value = SearchQueryList(query=["Ollama query"])
+
+    result_state = generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+    mock_chat_ollama.assert_called_once_with(
+        base_url="http://ollama:11434",
+        model="ollama-test-model",
+        temperature=1.0,
+    )
+    mock_chat_ollama.return_value.with_structured_output.assert_called_once_with(SearchQueryList)
+    assert result_state["query_list"] == ["Ollama query"]
+
+
+@patch("agent.graph.ChatOpenAI")
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_lmstudio_provider(mock_from_config, mock_chat_openai):
+    """Test generate_query uses ChatOpenAI when provider is LMSTUDIO."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.LMSTUDIO,
+        lmstudio_base_url="http://lmstudio:1234/v1",
+        lmstudio_model_name="lmstudio-test-model",
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    mock_structured_llm = MagicMock()
+    mock_chat_openai.return_value.with_structured_output.return_value = mock_structured_llm
+    mock_structured_llm.invoke.return_value = SearchQueryList(query=["LMStudio query"])
+
+    result_state = generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+    mock_chat_openai.assert_called_once_with(
+        base_url="http://lmstudio:1234/v1",
+        model_name="lmstudio-test-model",
+        api_key="not-needed",
+        temperature=1.0,
+        max_retries=2,
+    )
+    mock_chat_openai.return_value.with_structured_output.assert_called_once_with(SearchQueryList)
+    assert result_state["query_list"] == ["LMStudio query"]
+
+
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_ollama_missing_url_raises_error(mock_from_config):
+    """Test ValueError is raised if Ollama URL is missing."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.OLLAMA,
+        ollama_model_name="ollama-model", # URL is missing
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    with pytest.raises(ValueError, match="Ollama base URL or model name not configured"):
+        generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_ollama_missing_model_raises_error(mock_from_config):
+    """Test ValueError is raised if Ollama model name is missing."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.OLLAMA,
+        ollama_base_url="http://ollama:11434", # Model name is missing
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    with pytest.raises(ValueError, match="Ollama base URL or model name not configured"):
+        generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_lmstudio_missing_url_raises_error(mock_from_config):
+    """Test ValueError is raised if LMStudio URL is missing."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.LMSTUDIO,
+        lmstudio_model_name="lm-model", # URL is missing
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    with pytest.raises(ValueError, match="LM Studio base URL or model name not configured"):
+        generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_lmstudio_missing_model_raises_error(mock_from_config):
+    """Test ValueError is raised if LMStudio model name is missing."""
+    mock_config_instance = Configuration(
+        llm_provider=LLMProvider.LMSTUDIO,
+        lmstudio_base_url="http://lmstudio:1234/v1", # Model name is missing
+    )
+    mock_from_config.return_value = mock_config_instance
+
+    with pytest.raises(ValueError, match="LM Studio base URL or model name not configured"):
+        generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+@patch("agent.graph.Configuration.from_runnable_config")
+def test_generate_query_unsupported_provider_raises_error(mock_from_config):
+    """Test ValueError is raised for an unsupported LLM provider."""
+    mock_config_instance = MagicMock(spec=Configuration)
+    mock_config_instance.llm_provider = "unsupported_provider"
+    # To make Pydantic validation pass for the mock, if direct instantiation was used.
+    # But since we are mocking from_runnable_config's return, this is simpler.
+    mock_from_config.return_value = mock_config_instance
+
+    # Patching __str__ on the mock_config_instance.llm_provider if it's a MagicMock itself
+    if isinstance(mock_config_instance.llm_provider, MagicMock):
+      mock_config_instance.llm_provider.__str__.return_value = "unsupported_provider"
+
+
+    with pytest.raises(ValueError, match="Unsupported LLM provider: unsupported_provider"):
+        generate_query(mock_initial_state.copy(), mock_runnable_config)
+
+# To run these tests, you would typically use `pytest` in the terminal
+# Ensure that pytest and pytest-mock are installed in your environment.
+# These tests assume that os.getenv("GEMINI_API_KEY") returns None during tests.
+# If it's set globally, the Gemini test might behave differently regarding api_key.
+# The fixture in test_configuration.py clears common env vars, which is good practice.
+# For test_graph.py, if GEMINI_API_KEY is needed for some setup, it should be mocked too.
+# Here, api_key=None in ChatGoogleGenerativeAI call is expected if env var is not set.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,8 @@ services:
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
       REDIS_URI: redis://langgraph-redis:6379
       POSTGRES_URI: postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable
+      LLM_PROVIDER: "gemini"
+      OLLAMA_BASE_URL: "http://host.docker.internal:11434"
+      OLLAMA_MODEL_NAME: "llama2"
+      LMSTUDIO_BASE_URL: "http://host.docker.internal:1234/v1"
+      LMSTUDIO_MODEL_NAME: "local-model"

--- a/frontend/src/components/ConfigModal.tsx
+++ b/frontend/src/components/ConfigModal.tsx
@@ -1,0 +1,185 @@
+// frontend/src/components/ConfigModal.tsx
+import React from 'react';
+import { useConfig, LLMConfig } from '../contexts/ConfigContext';
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ReloadIcon } from "@radix-ui/react-icons";
+
+
+interface ConfigModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ConfigModal({ isOpen, onClose }: ConfigModalProps) {
+  const { llmConfig, updateConfig, resetToDefaults, isLoading } = useConfig();
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value, type } = e.target;
+    updateConfig({ [name]: type === 'password' ? value : value.trim() });
+  };
+
+  const handleSelectChange = (value: string) => {
+    updateConfig({ llmProvider: value as LLMConfig["llmProvider"] });
+  };
+
+  const handleReset = async () => {
+    if (window.confirm("Are you sure you want to reset all settings to their default values? This will fetch the latest defaults from the backend.")) {
+      await resetToDefaults();
+    }
+  };
+
+  if (isLoading || !llmConfig.isLoaded) {
+    return (
+      <Dialog open={isOpen} onOpenChange={onClose}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>Configuration</DialogTitle>
+          </DialogHeader>
+          <div className="p-4 text-center">
+            <ReloadIcon className="mr-2 h-4 w-4 animate-spin inline-block" />
+            Loading configuration...
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[525px] max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>LLM Configuration</DialogTitle>
+          <DialogDescription>
+            Manage settings for Language Model providers. Changes are saved automatically.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="llmProvider" className="text-right">
+              LLM Provider
+            </Label>
+            <Select
+              name="llmProvider"
+              value={llmConfig.llmProvider}
+              onValueChange={handleSelectChange}
+            >
+              <SelectTrigger className="col-span-3">
+                <SelectValue placeholder="Select a provider" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="gemini">Gemini</SelectItem>
+                <SelectItem value="ollama">Ollama</SelectItem>
+                <SelectItem value="lmstudio">LM Studio</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {llmConfig.llmProvider === 'gemini' && (
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="geminiApiKey" className="text-right">
+                Gemini API Key
+              </Label>
+              <Input
+                id="geminiApiKey"
+                name="geminiApiKey"
+                type="password"
+                value={llmConfig.geminiApiKey}
+                onChange={handleInputChange}
+                className="col-span-3"
+                placeholder="Enter your Gemini API Key"
+              />
+            </div>
+          )}
+
+          {llmConfig.llmProvider === 'ollama' && (
+            <>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="ollamaBaseUrl" className="text-right">
+                  Ollama URL
+                </Label>
+                <Input
+                  id="ollamaBaseUrl"
+                  name="ollamaBaseUrl"
+                  value={llmConfig.ollamaBaseUrl}
+                  onChange={handleInputChange}
+                  className="col-span-3"
+                  placeholder="e.g., http://localhost:11434"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="ollamaModelName" className="text-right">
+                  Ollama Model
+                </Label>
+                <Input
+                  id="ollamaModelName"
+                  name="ollamaModelName"
+                  value={llmConfig.ollamaModelName}
+                  onChange={handleInputChange}
+                  className="col-span-3"
+                  placeholder="e.g., llama2"
+                />
+              </div>
+            </>
+          )}
+
+          {llmConfig.llmProvider === 'lmstudio' && (
+            <>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="lmstudioBaseUrl" className="text-right">
+                  LM Studio URL
+                </Label>
+                <Input
+                  id="lmstudioBaseUrl"
+                  name="lmstudioBaseUrl"
+                  value={llmConfig.lmstudioBaseUrl}
+                  onChange={handleInputChange}
+                  className="col-span-3"
+                  placeholder="e.g., http://localhost:1234/v1"
+                />
+              </div>
+              <div className="grid grid-cols-4 items-center gap-4">
+                <Label htmlFor="lmstudioModelName" className="text-right">
+                  LM Studio Model
+                </Label>
+                <Input
+                  id="lmstudioModelName"
+                  name="lmstudioModelName"
+                  value={llmConfig.lmstudioModelName}
+                  onChange={handleInputChange}
+                  className="col-span-3"
+                  placeholder="e.g., Publisher/Model"
+                />
+              </div>
+            </>
+          )}
+        </div>
+        <DialogFooter className="sm:justify-between">
+            <Button type="button" variant="outline" onClick={handleReset}>
+                Reset to Defaults
+            </Button>
+          <DialogClose asChild>
+            <Button type="button">Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -1,0 +1,142 @@
+// frontend/src/contexts/ConfigContext.tsx
+import React, { createContext, useContext, useState, useEffect, ReactNode, useCallback } from 'react';
+
+const LOCAL_STORAGE_KEY = 'llmConfig';
+
+export interface LLMConfig {
+  llmProvider: "gemini" | "ollama" | "lmstudio" | "";
+  geminiApiKey: string;
+  ollamaBaseUrl: string;
+  ollamaModelName: string;
+  lmstudioBaseUrl: string;
+  lmstudioModelName: string;
+  isLoaded: boolean; // To track if settings have been loaded from local storage/backend
+}
+
+export interface ConfigContextType {
+  llmConfig: LLMConfig;
+  updateConfig: (newConfig: Partial<LLMConfig>) => void;
+  saveConfig: () => void; // Explicitly expose save if needed, though updateConfig handles it
+  resetToDefaults: () => Promise<void>;
+  isLoading: boolean; // Expose a loading state for initial load
+}
+
+const ConfigContext = createContext<ConfigContextType | undefined>(undefined);
+
+interface ConfigProviderProps {
+  children: ReactNode;
+}
+
+// Define initial/empty state structure
+const initialConfigState: LLMConfig = {
+  llmProvider: "",
+  geminiApiKey: "",
+  ollamaBaseUrl: "",
+  ollamaModelName: "",
+  lmstudioBaseUrl: "",
+  lmstudioModelName: "",
+  isLoaded: false,
+};
+
+export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
+  const [llmConfig, setLlmConfig] = useState<LLMConfig>(initialConfigState);
+  const [isLoading, setIsLoading] = useState<boolean>(true); // For initial load from backend/localStorage
+
+  const saveConfigToLocalStorage = useCallback((configToSave: LLMConfig) => {
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(configToSave));
+  }, []);
+
+  const fetchAndSetDefaults = useCallback(async (isInitialLoad = false) => {
+    if (!isInitialLoad) setIsLoading(true);
+    try {
+      const response = await fetch('/agent/config-defaults');
+      if (!response.ok) {
+        throw new Error(`Failed to fetch default config: ${response.statusText}`);
+      }
+      const defaults: Partial<LLMConfig> = await response.json();
+
+      // Ensure isLoaded is not part of what we get from backend, set it manually
+      const newConfig: LLMConfig = {
+        ...initialConfigState, // Start with a clean slate of known fields
+        llmProvider: defaults.llmProvider || "gemini", // Ensure provider has a fallback
+        geminiApiKey: defaults.geminiApiKey || "",
+        ollamaBaseUrl: defaults.ollamaBaseUrl || "",
+        ollamaModelName: defaults.ollamaModelName || "",
+        lmstudioBaseUrl: defaults.lmstudioBaseUrl || "",
+        lmstudioModelName: defaults.lmstudioModelName || "",
+        isLoaded: true,
+      };
+      setLlmConfig(newConfig);
+      saveConfigToLocalStorage(newConfig); // Save fetched defaults as the new baseline
+      console.log("Fetched and applied default configurations:", newConfig);
+    } catch (error) {
+      console.error("Error fetching default configurations:", error);
+      // In case of error, ensure we still have a valid state and mark as loaded
+      setLlmConfig(prevConfig => ({ ...prevConfig, isLoaded: true }));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [saveConfigToLocalStorage]);
+
+  useEffect(() => {
+    const loadStoredConfig = () => {
+      const storedConfigJson = localStorage.getItem(LOCAL_STORAGE_KEY);
+      if (storedConfigJson) {
+        try {
+          const storedConfig: LLMConfig = JSON.parse(storedConfigJson);
+          // Ensure all keys are present, even if old config was stored
+           const validatedConfig: LLMConfig = {
+            ...initialConfigState,
+            ...storedConfig,
+            isLoaded: true, // Mark as loaded from local storage
+          };
+          setLlmConfig(validatedConfig);
+          setIsLoading(false);
+          console.log("Loaded configuration from local storage:", validatedConfig);
+        } catch (e) {
+          console.error("Error parsing stored LLM config, fetching defaults.", e);
+          localStorage.removeItem(LOCAL_STORAGE_KEY); // Clear corrupted data
+          fetchAndSetDefaults(true);
+        }
+      } else {
+        console.log("No configuration found in local storage, fetching defaults.");
+        fetchAndSetDefaults(true);
+      }
+    };
+    loadStoredConfig();
+  }, [fetchAndSetDefaults]);
+
+  const updateConfig = useCallback((newConfig: Partial<LLMConfig>) => {
+    setLlmConfig(prevConfig => {
+      const updated = { ...prevConfig, ...newConfig, isLoaded: true };
+      saveConfigToLocalStorage(updated);
+      return updated;
+    });
+  }, [saveConfigToLocalStorage]);
+
+  const saveConfig = useCallback(() => {
+    saveConfigToLocalStorage(llmConfig);
+  }, [llmConfig, saveConfigToLocalStorage]);
+
+  const resetToDefaults = useCallback(async () => {
+    console.log("Resetting configuration to backend defaults.");
+    // Clear local storage first to ensure fresh fetch is not overridden by stale useEffect load
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+    await fetchAndSetDefaults();
+  }, [fetchAndSetDefaults]);
+
+
+  return (
+    <ConfigContext.Provider value={{ llmConfig, updateConfig, saveConfig, resetToDefaults, isLoading }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};
+
+export const useConfig = (): ConfigContextType => {
+  const context = useContext(ConfigContext);
+  if (context === undefined) {
+    throw new Error('useConfig must be used within a ConfigProvider');
+  }
+  return context;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import "./global.css";
 import App from "./App.tsx";
+import { ConfigProvider } from "./contexts/ConfigContext.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <ConfigProvider>
+        <App />
+      </ConfigProvider>
     </BrowserRouter>
   </StrictMode>
 );


### PR DESCRIPTION
This commit introduces a user interface for configuring LLM providers directly from the frontend. You can now dynamically select and set parameters for Gemini, Ollama, and LM Studio without needing to modify environment variables and restart the backend.

Key Changes:

**Backend (`backend/src/agent/`):**
-   `configuration.py`:
    -   Modified `Configuration.from_runnable_config` to prioritize settings passed in the `configurable` part of `RunnableConfig` (from frontend) over environment variables, then Pydantic defaults.
    -   Added `gemini_api_key` to the `Configuration` model to allow it to be set via UI.
-   `graph.py`:
    -   Updated `ChatGoogleGenerativeAI` instantiations to use `gemini_api_key` from the `Configuration` object.
    -   Added checks for missing essential configurations (e.g., API key for Gemini, URLs for Ollama/LMStudio) to raise errors if not provided.
    -   Clarified that the `web_research` node's `genai_client` still uses `GEMINI_API_KEY` from environment variables at startup for its specific Google Search functionality.
-   `app.py`:
    -   Added a new GET endpoint `/agent/config-defaults` that returns the current backend configuration based on environment variables and Pydantic defaults. This allows the frontend to initialize its settings.

**Frontend (`frontend/src/`):**
-   `contexts/ConfigContext.tsx`:
    -   Created a React context to manage LLM configuration state (provider, API keys, URLs, model names).
    -   Handles loading settings from local storage on initialization.
    -   Fetches defaults from the `/agent/config-defaults` backend endpoint if local storage is empty or reset.
    -   Saves your changes to local storage automatically.
    -   Provides functions to update and reset configurations.
-   `components/ConfigModal.tsx`:
    -   Developed a modal dialog with a form for you to:
        -   Select the LLM provider (Gemini, Ollama, LM Studio).
        -   Input provider-specific details (API key for Gemini, Base URLs and Model Names for Ollama/LM Studio).
        -   Reset settings to backend defaults.
    -   Uses Shadcn/ui components for a consistent look and feel.
-   `App.tsx`:
    -   Integrated the `ConfigModal`, making it accessible via a settings icon (gear button).
    -   Passes the UI-configured LLM settings (from `ConfigContext`) to the backend with each API request using the `configurable` field in `RunnableConfig`.
    -   Displays messages for configuration loading failures and reminders about web search limitations for non-Gemini providers.

**Documentation (`README.md`):**
-   Updated to document the new frontend configuration UI.
-   Explained the order of configuration precedence: UI (local storage) > environment variables > application defaults.
-   Detailed how to use the "Reset to Defaults" feature.

This feature significantly enhances your flexibility by allowing dynamic, per-session (or persisted in local storage) configuration of LLM providers and their settings directly through the UI.