### PR TITLE
Refactor: Decouple LangGraph Quickstart from cloud dependencies

### DIFF
--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -6,6 +6,7 @@ from langchain_core.messages import AIMessage
 from langgraph.types import Send
 from langgraph.graph import StateGraph
 from langgraph.graph import START, END
+from langgraph.checkpoint.memory import MemorySaver
 from langchain_core.runnables import RunnableConfig
 from google.genai import Client
 
@@ -290,4 +291,4 @@ builder.add_conditional_edges(
 # Finalize the answer
 builder.add_edge("finalize_answer", END)
 
-graph = builder.compile(name="pro-search-agent")
+graph = builder.compile(checkpointer=MemorySaver(), name="pro-search-agent")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,40 +2,10 @@ volumes:
   langgraph-data:
     driver: local
 services:
-  langgraph-redis:
-    image: docker.io/redis:6
-    healthcheck:
-      test: redis-cli ping
-      interval: 5s
-      timeout: 1s
-      retries: 5
-  langgraph-postgres:
-    image: docker.io/postgres:16
-    ports:
-      - "5433:5432"
-    environment:
-      POSTGRES_DB: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-    volumes:
-      - langgraph-data:/var/lib/postgresql/data
-    healthcheck:
-      test: pg_isready -U postgres
-      start_period: 10s
-      timeout: 1s
-      retries: 5
-      interval: 5s
   langgraph-api:
     image: gemini-fullstack-langgraph
     ports:
       - "8123:8000"
-    depends_on:
-      langgraph-redis:
-        condition: service_healthy
-      langgraph-postgres:
-        condition: service_healthy
     environment:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
-      REDIS_URI: redis://langgraph-redis:6379
-      POSTGRES_URI: postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable


### PR DESCRIPTION
This commit modifies the application to run without requiring Postgres, Redis, or LangSmith.

Key changes:
- Updated `docker-compose.yml` to remove Postgres and Redis services and related configurations.
- Created `backend/.env` to explicitly disable LangSmith tracing (`LANGCHAIN_TRACING_V2="false"`).
- Modified `backend/src/agent/graph.py` to hardcode the checkpointer to always use `langgraph.checkpoint.memory.MemorySaver`.

These changes allow the application to operate in a simplified, self-contained mode with in-memory state management, similar to the initial local setup.