### PR TITLE
Remove unused reflection_model and answer_model from configuration.py

### DIFF
--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -15,20 +15,6 @@ class Configuration(BaseModel):
         },
     )
 
-    reflection_model: str = Field(
-        default="gemini-2.5-flash-preview-04-17",
-        metadata={
-            "description": "The name of the language model to use for the agent's reflection."
-        },
-    )
-
-    answer_model: str = Field(
-        default="gemini-2.5-pro-preview-05-06",
-        metadata={
-            "description": "The name of the language model to use for the agent's answer."
-        },
-    )
-
     number_of_initial_queries: int = Field(
         default=3,
         metadata={"description": "The number of initial search queries to generate."},


### PR DESCRIPTION
## Summary
Removes unused `reflection_model` and `answer_model` fields from the Configuration class in `configuration.py`.

## Background
Through code analysis, it was discovered that while these model configurations are defined in the Configuration class, they are never actually used in the codebase:

- `configurable.reflection_model` - not referenced anywhere in the code
- `configurable.answer_model` - not referenced anywhere in the code

Instead, both the `reflection` and `finalize_answer` nodes use the same logic:
```python
reasoning_model = state.get("reasoning_model") or configurable.reasoning_model