### PR TITLE
add support for VITE_API_URL environment variable with sensible defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN npm install
 # Copy the rest of the frontend source code
 COPY frontend/ ./
 
+# Add the build argument for the backend API URL to be used by the frontend
+ARG VITE_API_URL
+
+# Set the environment variable so Vite can access the backend API URL during build
+ENV VITE_API_URL=${VITE_API_URL}
+
 # Build the frontend
 RUN npm run build
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,3 @@
 # GEMINI_API_KEY=
+# LANGSMITH_API_KEY=
+# VITE_API_URL=http://localhost:8123

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       retries: 5
       interval: 5s
   langgraph-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: ${VITE_API_URL}  
     image: gemini-fullstack-langgraph
     container_name: langgraph-api
     ports:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,9 +22,9 @@ export default function App() {
     max_research_loops: number;
     reasoning_model: string;
   }>({
-    apiUrl: import.meta.env.DEV
+    apiUrl: import.meta.env.VITE_API_URL || (import.meta.env.DEV
       ? "http://localhost:2024"
-      : "http://localhost:8123",
+      : "http://localhost:8123"),
     assistantId: "agent",
     messagesKey: "messages",
     onUpdateEvent: (event: any) => {


### PR DESCRIPTION
This update introduces a flexible mechanism to configure the backend API URL used by the frontend, removing the need to hardcode or manually edit the API endpoint within `App.tsx`. The main improvements are as follows:

- **Environment Variable Integration:**  
  The frontend now reads the API URL from an environment variable (`VITE_API_URL`) at build time. This variable can be defined in a `.env` file, passed as a build argument in Docker, or set via deployment configuration, making it easy to change the API endpoint for different environments (development, staging, production) without modifying the source code.

- **Build Process Adaptation:**  
  The Dockerfile and build scripts have been updated to accept the `VITE_API_URL` argument and expose it as an environment variable during the frontend build process. This ensures that the correct API URL is embedded into the frontend bundle according to the environment or deployment context.

- **Docker Compose Integration:**  
  The `docker-compose.yaml` file has been updated to support building the entire project directly with Docker Compose. It now passes the `VITE_API_URL` environment variable as a build argument, enabling seamless configuration of the API endpoint during the build process without manual intervention.

- **Fallback Logic:**  
  In the application code, the API URL is now resolved using the following logic:
  - Use the value of `import.meta.env.VITE_API_URL` if defined and non-empty.
  - Otherwise, fallback to sensible defaults based on the build environment (e.g., localhost for development, a production URL otherwise).
  This allows for robust configuration with minimal manual intervention.

- **No Need to Edit Source Files:**
  With this approach, updating the API endpoint only requires changing the environment variable or build argument, not the application source code. This streamlines deployments and reduces the risk of manual errors.

**In summary:**
The frontend’s API URL is now fully configurable via environment variables and can be set per environment using Docker Compose. The project can be built directly from Docker Compose with the appropriate API endpoint, supporting per-environment deployments and simplifying the process of targeting different backend endpoints—all without requiring changes to `App.tsx` or other source files.