### PR TITLE
Refactor: Simplify Build Path and Update Generative AI Configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ dev-frontend:
 
 dev-backend:
 	@echo "Starting backend development server..."
-	@cd backend && langgraph dev
+	@cd backend && langgraph dev --no-browser
 
 # Run frontend and backend concurrently
 dev:

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ dev-frontend:
 
 dev-backend:
 	@echo "Starting backend development server..."
-	@cd backend && langgraph dev --no-browser
+	@cd backend && langgraph dev
 
 # Run frontend and backend concurrently
 dev:

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Langgraph flow
+_langgraph_flow/

--- a/backend/src/agent/app.py
+++ b/backend/src/agent/app.py
@@ -1,5 +1,6 @@
 # mypy: disable - error - code = "no-untyped-def,misc"
 import pathlib
+import os
 from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -16,7 +17,8 @@ def create_frontend_router(build_dir="../frontend/dist"):
     Returns:
         A Starlette application serving the frontend.
     """
-    build_path = pathlib.Path(__file__).parent.parent.parent / build_dir
+    project_root = pathlib.Path(__file__).resolve().parents[3]
+    build_path = project_root / build_dir
 
     if not build_path.is_dir() or not (build_path / "index.html").is_file():
         print(

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -301,7 +301,7 @@ builder.add_edge("finalize_answer", END)
 
 graph = builder.compile(name="pro-search-agent")
 
-# save the flow image to file
+# Save the flow image to file
 search_flow = graph.get_graph().draw_mermaid_png()
 save_dir = os.path.join(os.path.dirname(__file__), "_langgraph_flow")
 os.makedirs(save_dir, exist_ok=True)

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -7,7 +7,7 @@ from langgraph.types import Send
 from langgraph.graph import StateGraph
 from langgraph.graph import START, END
 from langchain_core.runnables import RunnableConfig
-from google.genai import Client
+from google.genai import Client, types
 
 from agent.state import (
     OverallState,
@@ -111,14 +111,22 @@ def web_research(state: WebSearchState, config: RunnableConfig) -> OverallState:
         research_topic=state["search_query"],
     )
 
+    #Define grounding tool use
+    grounding_tool = types.Tool(
+        google_search=types.GoogleSearch(),
+    )
+
+    #Setup config
+    config = types.GenerateContentConfig(
+        tools=[grounding_tool],
+        temperature=0,
+    )
+
     # Uses the google genai client as the langchain client doesn't return grounding metadata
     response = genai_client.models.generate_content(
         model=configurable.query_generator_model,
         contents=formatted_prompt,
-        config={
-            "tools": [{"google_search": {}}],
-            "temperature": 0,
-        },
+        config=config,
     )
     # resolve the urls to short urls for saving tokens and time
     resolved_urls = resolve_urls(

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime
 
 from agent.tools_and_schemas import SearchQueryList, Reflection
 from dotenv import load_dotenv
@@ -299,3 +300,16 @@ builder.add_conditional_edges(
 builder.add_edge("finalize_answer", END)
 
 graph = builder.compile(name="pro-search-agent")
+
+# save the flow image to file
+search_flow = graph.get_graph().draw_mermaid_png()
+save_dir = os.path.join(os.path.dirname(__file__), "_langgraph_flow")
+os.makedirs(save_dir, exist_ok=True)
+
+# Generate unique filename with timestamp
+timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+filename = os.path.join(save_dir, f"search_flow_{timestamp}.png")
+
+# Save to current directory
+with open(filename, "wb") as f:
+    f.write(search_flow)

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -1,5 +1,4 @@
 import os
-from datetime import datetime
 
 from agent.tools_and_schemas import SearchQueryList, Reflection
 from dotenv import load_dotenv
@@ -300,16 +299,3 @@ builder.add_conditional_edges(
 builder.add_edge("finalize_answer", END)
 
 graph = builder.compile(name="pro-search-agent")
-
-# Save the flow image to file
-search_flow = graph.get_graph().draw_mermaid_png()
-save_dir = os.path.join(os.path.dirname(__file__), "_langgraph_flow")
-os.makedirs(save_dir, exist_ok=True)
-
-# Generate unique filename with timestamp
-timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-filename = os.path.join(save_dir, f"search_flow_{timestamp}.png")
-
-# Save to current directory
-with open(filename, "wb") as f:
-    f.write(search_flow)

--- a/backend/src/agent/state.py
+++ b/backend/src/agent/state.py
@@ -9,7 +9,6 @@ from typing_extensions import Annotated
 
 import operator
 
-
 class OverallState(TypedDict):
     messages: Annotated[list, add_messages]
     search_query: Annotated[list, operator.add]
@@ -20,6 +19,9 @@ class OverallState(TypedDict):
     research_loop_count: int
     reasoning_model: str
 
+class WebSearchState(TypedDict):
+    search_query: str
+    id: str
 
 class ReflectionState(TypedDict):
     is_sufficient: bool
@@ -28,20 +30,12 @@ class ReflectionState(TypedDict):
     research_loop_count: int
     number_of_ran_queries: int
 
-
 class Query(TypedDict):
     query: str
     rationale: str
 
-
 class QueryGenerationState(TypedDict):
     search_query: list[Query]
-
-
-class WebSearchState(TypedDict):
-    search_query: str
-    id: str
-
 
 @dataclass(kw_only=True)
 class SearchStateOutput:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Google Search Agent</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     },
   },
   server: {
+    port: 5174,
     proxy: {
       // Proxy API requests to the backend server
       "/api": {


### PR DESCRIPTION
This pull request introduces two key refactorings to improve code clarity and align with the latest library standards.

### 1. Simplified Build Path

The build path logic has been refactored to remove the repetitive use of `parents.parents.parents...`. This results in a more readable manner.

### 2. Updated `generate_content` Configuration

During a review of the `generate_content` function, I noticed the use of a `config` dictionary to set `tools` and `temperature`. While this approach functions, it appears to be based on a previous version of the API, as suggested by the [deprecated generative-ai-python repository](https://github.com/google-gemini/deprecated-generative-ai-python).

The official [Google AI for Developers documentation](https://ai.google.dev/gemini-api/docs/function-calling) use `types.generatecontentconfig` instead of using the old way.

**Old Configuration:**
```python
config = {
    'tools': [{'Google Search': {}}],
    'temperature': 0,
}
# model.generate_content(..., config=config) # Likely older usage
```

I have updated the implementation to reflect this modern usage. If there is a specific reason for retaining the legacy config structure, I would be very interested to learn about it.