### PR TITLE
Add the port to vite.config.ts

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     },
   },
   server: {
+    port: 5174,
     proxy: {
       // Proxy API requests to the backend server
       "/api": {


### PR DESCRIPTION
Summary

This pull request resolves an issue where the Vite development server was launching on an unpredictable port by explicitly setting it to 5174.

Motivation

The Vite server would sometimes occupy both port 5173 (the default) and 5174 without a clear reason, leading to confusion and making it difficult to reliably access the application. This change ensures the frontend server runs on a single, consistent port, which improves the local development experience.