### PR TITLE
Fix Duplication in search query and number of ran queries

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "langgraph>=0.2.6",
     "langchain>=0.3.19",

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -41,7 +41,7 @@ genai_client = Client(api_key=os.getenv("GEMINI_API_KEY"))
 
 
 # Nodes
-def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerationState:
+def generate_query(state: OverallState, config: RunnableConfig) -> OverallState:
     """LangGraph node that generates search queries based on the User's question.
 
     Uses Gemini 2.0 Flash to create an optimized search queries for web research based on
@@ -78,17 +78,17 @@ def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerati
     )
     # Generate the search queries
     result = structured_llm.invoke(formatted_prompt)
-    return {"search_query": result.query}
+    return {"generated_query": result.query}
 
 
-def continue_to_web_research(state: QueryGenerationState):
+def continue_to_web_research(state: OverallState):
     """LangGraph node that sends the search queries to the web research node.
 
     This is used to spawn n number of web research nodes, one for each search query.
     """
     return [
         Send("web_research", {"search_query": search_query, "id": int(idx)})
-        for idx, search_query in enumerate(state["search_query"])
+        for idx, search_query in enumerate(state["generated_query"])
     ]
 
 

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -253,9 +253,11 @@ def finalize_answer(state: OverallState, config: RunnableConfig):
     # Replace the short urls with the original urls and add all used urls to the sources_gathered
     unique_sources = []
     for source in state["sources_gathered"]:
-        if source["short_url"] in result.content:
+        short_url = f"({source['short_url']})"
+        if short_url in result.content:
+            value = f"({source['value']})"
             result.content = result.content.replace(
-                source["short_url"], source["value"]
+                short_url, value
             )
             unique_sources.append(source)
 

--- a/backend/src/agent/state.py
+++ b/backend/src/agent/state.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TypedDict
+from typing import TypedDict, Annotated
 
 from langgraph.graph import add_messages
-from typing_extensions import Annotated
 
 
 import operator
@@ -12,6 +11,7 @@ import operator
 
 class OverallState(TypedDict):
     messages: Annotated[list, add_messages]
+    generated_query: list[str]
     search_query: Annotated[list, operator.add]
     web_research_result: Annotated[list, operator.add]
     sources_gathered: Annotated[list, operator.add]


### PR DESCRIPTION
# Related Issues: #141 

# Changes

- Update in OverallState to save generated query instead of in search query (it will duplicate).
- tying from python 3.12, remove typing extensions (better supported in Python 3.12)