### PR TITLE
fix: update model name to match backend configuration

### DIFF
--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -26,7 +26,7 @@ export const InputForm: React.FC<InputFormProps> = ({
 }) => {
   const [internalInputValue, setInternalInputValue] = useState("");
   const [effort, setEffort] = useState("medium");
-  const [model, setModel] = useState("gemini-2.5-flash-preview-04-17");
+  const [model, setModel] = useState("gemini-2.5-flash");
 
   const handleInternalSubmit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
@@ -144,7 +144,7 @@ export const InputForm: React.FC<InputFormProps> = ({
                   </div>
                 </SelectItem>
                 <SelectItem
-                  value="gemini-2.5-flash-preview-04-17"
+                  value="gemini-2.5-flash"
                   className="hover:bg-neutral-600 focus:bg-neutral-600 cursor-pointer"
                 >
                   <div className="flex items-center">


### PR DESCRIPTION
## Description
This PR fixes a model name mismatch between the frontend and backend configurations. The frontend was using an incorrect model name `gemini-2.5-flash-preview-04-17` which was causing 404 errors. This updates it to match the backend's configured model name `gemini-2.5-flash`.

## Changes Made
- Updated the default model name in [InputForm.tsx](cci:7://file:///c:/Users/galah/MyCodes/Projectz/opensource/gemini-langgraph/gemini-fullstack-langgraph-quickstart/frontend/src/components/InputForm.tsx:0:0-0:0) from `gemini-2.5-flash-preview-04-17` to `gemini-2.5-flash`

## Testing
- [x] Verified that the application runs without model-related errors
- [x] Confirmed that the correct model is being used in the frontend


## Screenshots 
<img width="1569" height="379" alt="image" src="https://github.com/user-attachments/assets/7650ccbe-a5b2-4a2a-9962-62b541248f6c" />
