### PR TITLE
Update code to use Groq for reasoning and generating answer

### DIFF
--- a/backend/examples/cli_research.py
+++ b/backend/examples/cli_research.py
@@ -21,7 +21,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--reasoning-model",
-        default="gemini-2.5-pro-preview-05-06",
+        default="llama-3.3-70b-versatile",
         help="Model for the final answer",
     )
     args = parser.parse_args()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.11,<4.0"
 dependencies = [
     "langgraph>=0.2.6",
     "langchain>=0.3.19",
-    "langchain-google-genai",
+    "langchain-groq>=0.1.0",
     "python-dotenv>=1.0.1",
     "langgraph-sdk>=0.1.57",
     "langgraph-cli",

--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -16,14 +16,14 @@ class Configuration(BaseModel):
     )
 
     reflection_model: str = Field(
-        default="gemini-2.5-flash",
+        default="llama-3.3-70b-versatile",
         metadata={
             "description": "The name of the language model to use for the agent's reflection."
         },
     )
 
     answer_model: str = Field(
-        default="gemini-2.5-pro",
+        default="llama-3.3-70b-versatile",
         metadata={
             "description": "The name of the language model to use for the agent's answer."
         },

--- a/backend/src/agent/graph.py
+++ b/backend/src/agent/graph.py
@@ -23,7 +23,7 @@ from agent.prompts import (
     reflection_instructions,
     answer_instructions,
 )
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_groq import ChatGroq
 from agent.utils import (
     get_citations,
     get_research_topic,
@@ -33,8 +33,8 @@ from agent.utils import (
 
 load_dotenv()
 
-if os.getenv("GEMINI_API_KEY") is None:
-    raise ValueError("GEMINI_API_KEY is not set")
+if os.getenv("GROQ_API_KEY") is None:
+    raise ValueError("GROQ_API_KEY is not set")
 
 # Used for Google Search API
 genai_client = Client(api_key=os.getenv("GEMINI_API_KEY"))
@@ -44,7 +44,7 @@ genai_client = Client(api_key=os.getenv("GEMINI_API_KEY"))
 def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerationState:
     """LangGraph node that generates search queries based on the User's question.
 
-    Uses Gemini 2.0 Flash to create an optimized search queries for web research based on
+    Uses Llama 3.3 70B Versatile (Groq) to create an optimized search queries for web research based on
     the User's question.
 
     Args:
@@ -60,12 +60,12 @@ def generate_query(state: OverallState, config: RunnableConfig) -> QueryGenerati
     if state.get("initial_search_query_count") is None:
         state["initial_search_query_count"] = configurable.number_of_initial_queries
 
-    # init Gemini 2.0 Flash
-    llm = ChatGoogleGenerativeAI(
-        model=configurable.query_generator_model,
+    # init Llama 3.3 70B Versatile (Groq)
+    llm = ChatGroq(
+        model="llama-3.3-70b-versatile",
         temperature=1.0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
+        api_key=os.getenv("GROQ_API_KEY")
     )
     structured_llm = llm.with_structured_output(SearchQueryList)
 
@@ -163,11 +163,11 @@ def reflection(state: OverallState, config: RunnableConfig) -> ReflectionState:
         summaries="\n\n---\n\n".join(state["web_research_result"]),
     )
     # init Reasoning Model
-    llm = ChatGoogleGenerativeAI(
-        model=reasoning_model,
+    llm = ChatGroq(
+        model="llama-3.3-70b-versatile",
         temperature=1.0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
+        api_key=os.getenv("GROQ_API_KEY")
     )
     result = llm.with_structured_output(Reflection).invoke(formatted_prompt)
 
@@ -241,12 +241,12 @@ def finalize_answer(state: OverallState, config: RunnableConfig):
         summaries="\n---\n\n".join(state["web_research_result"]),
     )
 
-    # init Reasoning Model, default to Gemini 2.5 Flash
-    llm = ChatGoogleGenerativeAI(
-        model=reasoning_model,
+    # init Reasoning Model, default to Llama 3.3 70B Versatile (Groq)
+    llm = ChatGroq(
+        model="llama-3.3-70b-versatile",
         temperature=0,
         max_retries=2,
-        api_key=os.getenv("GEMINI_API_KEY"),
+        api_key=os.getenv("GROQ_API_KEY")
     )
     result = llm.invoke(formatted_prompt)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
         condition: service_healthy
     environment:
       GEMINI_API_KEY: ${GEMINI_API_KEY}
+      GROQ_API_KEY: ${GROQ_API_KEY}
       LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
       REDIS_URI: redis://langgraph-redis:6379
       POSTGRES_URI: postgres://postgres:postgres@langgraph-postgres:5432/postgres?sslmode=disable


### PR DESCRIPTION
### Replace Gemini with Llama 3.3 70B Versatile from Groq.
Refactored research agent to use Groq's llama-3.3-70b-versatile, eliminating Gemini quota dependency.

**Model replacement compatibility:**
ChatGoogleGenerativeAI → ChatGroq
- 3 reasoning nodes: generate_query, reflection, finalize_answer

**API configuration:**
GEMINI_API_KEY → GROQ_API_KEY 
- Updated validation & docker-compose

**CLI argument update:**
cli_research.py: "gemini-2.5-pro-preview-05-06" → "llama-3.3-70b-versatile"

**Dependency injection:**
pyproject.toml: langchain-google-genai → langchain-groq>=0.1.0
configuration.py: Updated model defaults
