### PR TITLE
fix: update deprecated Gemini model names to supported versions

### DIFF
--- a/backend/src/agent/configuration.py
+++ b/backend/src/agent/configuration.py
@@ -9,7 +9,7 @@ class Configuration(BaseModel):
     """The configuration for the agent."""
 
     query_generator_model: str = Field(
-        default="gemini-2.0-flash",
+        default="gemini-2.5-flash",
         metadata={
             "description": "The name of the language model to use for the agent's query generation."
         },

--- a/frontend/src/components/InputForm.tsx
+++ b/frontend/src/components/InputForm.tsx
@@ -26,7 +26,7 @@ export const InputForm: React.FC<InputFormProps> = ({
 }) => {
   const [internalInputValue, setInternalInputValue] = useState("");
   const [effort, setEffort] = useState("medium");
-  const [model, setModel] = useState("gemini-2.5-flash-preview-04-17");
+  const [model, setModel] = useState("gemini-2.5-flash");
 
   const handleInternalSubmit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
@@ -136,15 +136,7 @@ export const InputForm: React.FC<InputFormProps> = ({
               </SelectTrigger>
               <SelectContent className="bg-neutral-700 border-neutral-600 text-neutral-300 cursor-pointer">
                 <SelectItem
-                  value="gemini-2.0-flash"
-                  className="hover:bg-neutral-600 focus:bg-neutral-600 cursor-pointer"
-                >
-                  <div className="flex items-center">
-                    <Zap className="h-4 w-4 mr-2 text-yellow-400" /> 2.0 Flash
-                  </div>
-                </SelectItem>
-                <SelectItem
-                  value="gemini-2.5-flash-preview-04-17"
+                  value="gemini-2.5-flash"
                   className="hover:bg-neutral-600 focus:bg-neutral-600 cursor-pointer"
                 >
                   <div className="flex items-center">
@@ -152,7 +144,7 @@ export const InputForm: React.FC<InputFormProps> = ({
                   </div>
                 </SelectItem>
                 <SelectItem
-                  value="gemini-2.5-pro-preview-05-06"
+                  value="gemini-2.5-pro"
                   className="hover:bg-neutral-600 focus:bg-neutral-600 cursor-pointer"
                 >
                   <div className="flex items-center">


### PR DESCRIPTION
## Problem
Several Gemini model names used in this project are deprecated and return 
404 errors for new users, making the project impossible to run out of the box.

- `gemini-2.0-flash`: no longer available to new users. Google has officially 
  announced deprecation with shutdown scheduled for June 1, 2026.
- `gemini-2.5-flash-preview-04-17`: not found for API version v1beta
- `gemini-2.5-pro-preview-05-06`: not found for API version v1beta

## Changes
- `backend/src/agent/configuration.py`: updated `query_generator_model` default 
  from `gemini-2.0-flash` to `gemini-2.5-flash`
- `frontend/src/components/InputForm.tsx`: 
  - updated default model from `gemini-2.5-flash-preview-04-17` to `gemini-2.5-flash`
  - removed deprecated `gemini-2.0-flash` dropdown option
  - updated `gemini-2.5-flash-preview-04-17` option value to `gemini-2.5-flash`
  - updated `gemini-2.5-pro-preview-05-06` option value to `gemini-2.5-pro`